### PR TITLE
Improve JNIHook resilience for re-injection into a running JVM

### DIFF
--- a/src/jnihook.cpp
+++ b/src/jnihook.cpp
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cinttypes>
 #include <jnif.hpp>
 #include "jvm.hpp"
 #include "uuid.hpp"
@@ -472,7 +473,7 @@ static void save_jvmti(JNIEnv *env, jvmtiEnv *jvmti)
                 "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
         if (!setProp) { env->ExceptionClear(); env->DeleteLocalRef(sysClass); return; }
         char buf[32];
-        snprintf(buf, sizeof(buf), "%lx", (unsigned long)(uintptr_t)jvmti);
+        snprintf(buf, sizeof(buf), "%" PRIxPTR, (uintptr_t)jvmti);
         jstring key = env->NewStringUTF("__jnihook_jvmti");
         jstring val = env->NewStringUTF(buf);
         env->CallStaticObjectMethod(sysClass, setProp, key, val);
@@ -556,7 +557,6 @@ JNIHook_Init(JavaVM *jvm)
 
         auto flags_buf = *(unsigned char **)flagsField; // flagTable
         auto numFlags = *numFlagsField;
-        int patched = 0;
         for (size_t i = 0; i < numFlags; ++i) {
                 auto flag = VMType::from_instance(jvm_flag_type.get_type_name().c_str(), &flags_buf[i * jvm_flag_size]);
                 auto name_addr = flag->get_field<void *>("_name").value();
@@ -570,7 +570,6 @@ JNIHook_Init(JavaVM *jvm)
                         auto addr = *flag->get_field<bool *>("_addr").value();
                         auto value = reinterpret_cast<bool *>(addr);
                         *value = true;
-                        patched++;
                 }
                 // BytecodeVerificationLocal/Remote: disable verification so
                 // RedefineClasses works on classes loaded with -noverify
@@ -579,7 +578,6 @@ JNIHook_Init(JavaVM *jvm)
                         auto addr = *flag->get_field<bool *>("_addr").value();
                         auto value = reinterpret_cast<bool *>(addr);
                         *value = false;
-                        patched++;
                 }
         }
 
@@ -729,7 +727,7 @@ JNIHook_Attach(jmethodID method, void *native_hook_method, jmethodID *original_m
                 LOG("ERR: JNIF exception thrown -> %s\n", ex.message.c_str());
                 return JNIHOOK_ERR_CLASS_FILE_FORMAT;
         } catch (std::exception &ex) {
-                LOG("ERR: Unhandled exception thrown\n");
+                LOG("ERR: Unhandled exception thrown: %s\n", ex.what());
         } catch (...) {
                 LOG("ERR: Unhandled exception thrown\n");
         }

--- a/src/jnihook.cpp
+++ b/src/jnihook.cpp
@@ -28,6 +28,9 @@
 #include <unordered_map>
 #include <string>
 #include <vector>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <jnif.hpp>
 #include "jvm.hpp"
@@ -37,6 +40,20 @@
 #else
         #define LOG(...)
 #endif
+
+// File-based debug logging (always active)
+static inline void jnihook_log(const char *fmt, ...) {
+        FILE *f = fopen("/tmp/inspection.log", "a");
+        if (!f) return;
+        va_list ap;
+        va_start(ap, fmt);
+        fprintf(f, "[jnihook] ");
+        vfprintf(f, fmt, ap);
+        fputc('\n', f);
+        va_end(ap);
+        fclose(f);
+}
+#define LOGF(...) jnihook_log(__VA_ARGS__)
 
 extern "C" JNIIMPORT VMStructEntry *gHotSpotVMStructs;
 extern "C" JNIIMPORT VMTypeEntry *gHotSpotVMTypes;
@@ -154,7 +171,17 @@ void JNICALL JNIHook_ClassFileLoadHook(jvmtiEnv *jvmti_env,
                                        jint* new_class_data_len,
                                        unsigned char** new_class_data)
 {
+        // class_being_redefined is NULL for new class loads (not retransform).
+        // Calling get_class_name on NULL throws a JNI exception that poisons
+        // the ongoing RetransformClasses call (JVMTI_ERROR_FAILS_VERIFICATION).
+        if (!class_being_redefined) {
+                LOGF("ClassFileLoadHook: class_being_redefined=NULL, skipping (name=%s)", name ? name : "(null)");
+                return;
+        }
+
         auto class_name = get_class_name(jni_env, class_being_redefined);
+        LOGF("ClassFileLoadHook: name='%s' force_cache=%d",
+             class_name.c_str(), (int)g_force_class_caching);
 
         // Don't do anything for unhooked classes
         // (unless g_force_class_caching is true)
@@ -201,7 +228,9 @@ ReapplyClass(jclass clazz, std::string clazz_name)
 {
         jvmtiClassDefinition class_definition;
         jvmtiError err;
+        LOGF("ReapplyClass: clazz_name='%s'", clazz_name.c_str());
         auto cf = g_class_file_cache[clazz_name]->clone();
+        LOGF("ReapplyClass: cloned, methods=%zu hooks=%zu", cf->methods.size(), g_hooks[clazz_name].size());
 
         // Patch class file
         // NOTE: The `methods` attribute only has the methods defined by the main class of this ClassFile
@@ -248,12 +277,15 @@ ReapplyClass(jclass clazz, std::string clazz_name)
         }
 
         // Redefine class with modified ClassFile
+        LOGF("ReapplyClass: calling toBytes()");
         auto cf_bytes = cf->toBytes();
+        LOGF("ReapplyClass: toBytes ok, size=%zu", cf_bytes.size());
 
         class_definition.klass = clazz;
         class_definition.class_byte_count = cf_bytes.size();
         class_definition.class_bytes = cf_bytes.data();
         err = g_jnihook->jvmti->RedefineClasses(1, &class_definition);
+        LOGF("ReapplyClass: RedefineClasses -> %d", (int)err);
         std::stringstream ss;
         LOG("===== CLASS REAPPLIED =====\n");
         ss << *cf;
@@ -273,40 +305,38 @@ jnihook_result_t
 CacheClass(JNIEnv *env, jclass clazz)
 {
         std::string clazz_name = get_class_name(env, clazz);
+        LOGF("CacheClass: clazz_name='%s'", clazz_name.c_str());
 
         if (g_class_file_cache.find(clazz_name) == g_class_file_cache.end()) {
-                if (g_jnihook->jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL) != JVMTI_ERROR_NONE) {
+                auto enableRes = g_jnihook->jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL);
+                LOGF("CacheClass: EnableEvent -> %d", (int)enableRes);
+                if (enableRes != JVMTI_ERROR_NONE) {
                         LOG("ERR: Failed to enable class file load hook\n");
                         return JNIHOOK_ERR_SETUP_CLASS_FILE_LOAD_HOOK;
                 }
 
-                // Enable forceful caching of classfiles
-                // WARN: If something goes wrong, every class
-                // that goes through the ClassFileLoadHook
-                // would get cached! May waste a ton of memory.
                 g_force_class_caching = true;
                 auto result = g_jnihook->jvmti->RetransformClasses(1, &clazz);
                 g_force_class_caching = false;
+                LOGF("CacheClass: RetransformClasses -> %d", (int)result);
 
-                // NOTE: We disable the ClassFileLoadHook here because it breaks
-                //       any `env->DefineClass()` calls. Also, it's not necessary
-                //       to keep it active at all times, we just have to use it for caching
-                //       classes that havent been cached yet.
-                // TODO: Investigate why it breaks it (possibly NullPointerException in
-                //       JNIHook_ClassFileLoadHook)
-                if (g_jnihook->jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL) != JVMTI_ERROR_NONE) {
+                auto disableRes = g_jnihook->jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL);
+                LOGF("CacheClass: DisableEvent -> %d", (int)disableRes);
+                if (disableRes != JVMTI_ERROR_NONE) {
                         LOG("ERR: Failed to disable class file load hook\n");
                         return JNIHOOK_ERR_SETUP_CLASS_FILE_LOAD_HOOK;
                 }
 
-                if (result != JVMTI_ERROR_NONE) {
-                        LOG("ERR: Failed to cache classfile (JVMTI error)\n");
-                        return JNIHOOK_ERR_CLASS_FILE_CACHE;
-                }
-
+                // Even if RetransformClasses returned an error (e.g. verification
+                // failure), the ClassFileLoadHook may have already cached the
+                // class bytes, which is all we need for hooking.
                 if (g_class_file_cache.find(clazz_name) == g_class_file_cache.end()) {
+                        LOGF("CacheClass: FAIL class not cached, RetransformClasses error=%d", (int)result);
                         LOG("ERR: Failed to cache classfile\n");
                         return JNIHOOK_ERR_CLASS_FILE_CACHE;
+                }
+                if (result != JVMTI_ERROR_NONE) {
+                        LOGF("CacheClass: RetransformClasses error=%d but class is cached, proceeding", (int)result);
                 }
         }
 
@@ -442,17 +472,73 @@ CopyClass(JNIEnv *env, jclass clazz, const std::string &new_class_name, std::str
 }
 */
 
+// Helper: read a saved jvmtiEnv* from System.getProperty
+static jvmtiEnv *load_saved_jvmti(JNIEnv *env)
+{
+        jclass sysClass = env->FindClass("java/lang/System");
+        if (!sysClass) { env->ExceptionClear(); return nullptr; }
+        jmethodID getProp = env->GetStaticMethodID(sysClass, "getProperty",
+                "(Ljava/lang/String;)Ljava/lang/String;");
+        if (!getProp) { env->ExceptionClear(); env->DeleteLocalRef(sysClass); return nullptr; }
+        jstring key = env->NewStringUTF("__jnihook_jvmti");
+        jstring val = (jstring)env->CallStaticObjectMethod(sysClass, getProp, key);
+        env->DeleteLocalRef(key);
+        env->DeleteLocalRef(sysClass);
+        if (!val) return nullptr;
+        const char *str = env->GetStringUTFChars(val, nullptr);
+        if (!str) { env->DeleteLocalRef(val); return nullptr; }
+        jvmtiEnv *saved = reinterpret_cast<jvmtiEnv *>(strtoull(str, nullptr, 16));
+        LOG("Loaded saved jvmtiEnv: %s -> %p", str, saved);
+        env->ReleaseStringUTFChars(val, str);
+        env->DeleteLocalRef(val);
+        return saved;
+}
+
+// Helper: save jvmtiEnv* into System.setProperty
+static void save_jvmti(JNIEnv *env, jvmtiEnv *jvmti)
+{
+        jclass sysClass = env->FindClass("java/lang/System");
+        if (!sysClass) { env->ExceptionClear(); return; }
+        jmethodID setProp = env->GetStaticMethodID(sysClass, "setProperty",
+                "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+        if (!setProp) { env->ExceptionClear(); env->DeleteLocalRef(sysClass); return; }
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%lx", (unsigned long)(uintptr_t)jvmti);
+        jstring key = env->NewStringUTF("__jnihook_jvmti");
+        jstring val = env->NewStringUTF(buf);
+        env->CallStaticObjectMethod(sysClass, setProp, key, val);
+        LOG("Saved jvmtiEnv: %s", buf);
+        env->DeleteLocalRef(val);
+        env->DeleteLocalRef(key);
+        env->DeleteLocalRef(sysClass);
+}
+
 JNIHOOK_API jnihook_result_t JNIHOOK_CALL
 JNIHook_Init(JavaVM *jvm)
 {
-        jvmtiEnv *jvmti;
+        jvmtiEnv *jvmti = nullptr;
         jvmtiCapabilities capabilities = {};
         jvmtiEventCallbacks callbacks = {};
 
+        // If a previous injection left a saved jvmtiEnv, dispose it first
+        // to release its capabilities so a fresh env can acquire them.
+        JNIEnv *jni = nullptr;
+        jvm->GetEnv(reinterpret_cast<void **>(&jni), JNI_VERSION_1_8);
+        LOGF("Init: jni=%p", jni);
+        if (jni) {
+                jvmtiEnv *old_jvmti = load_saved_jvmti(jni);
+                if (old_jvmti) {
+                        LOGF("Init: disposing old jvmti=%p", old_jvmti);
+                        old_jvmti->DisposeEnvironment();
+                }
+        }
+
         if (jvm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION_1_2) != JNI_OK) {
+                LOGF("Init: GetEnv JVMTI failed");
                 LOG("ERR: Failed to get JVMTI");
                 return JNIHOOK_ERR_GET_JVMTI;
         }
+        LOGF("Init: new jvmti=%p", jvmti);
 
         capabilities.can_redefine_classes = 1;
         capabilities.can_redefine_any_class = 1;
@@ -460,9 +546,16 @@ JNIHook_Init(JavaVM *jvm)
         capabilities.can_retransform_any_class = 1;
         capabilities.can_suspend = 1;
 
-        if (jvmti->AddCapabilities(&capabilities) != JVMTI_ERROR_NONE) {
+        auto capRes = jvmti->AddCapabilities(&capabilities);
+        LOGF("Init: AddCapabilities -> %d", (int)capRes);
+        if (capRes != JVMTI_ERROR_NONE) {
                 LOG("ERR: Failed to add capabilities");
                 return JNIHOOK_ERR_ADD_JVMTI_CAPS;
+        }
+
+        // Save this jvmtiEnv for future injections
+        if (jni) {
+                save_jvmti(jni, jvmti);
         }
 
         callbacks.ClassFileLoadHook = JNIHook_ClassFileLoadHook;
@@ -499,26 +592,40 @@ JNIHook_Init(JavaVM *jvm)
 
         auto flags_buf = *(unsigned char **)flagsField; // flagTable
         auto numFlags = *numFlagsField;
+        LOGF("Init: scanning %zu JVM flags", (size_t)numFlags);
+        int patched = 0;
         for (size_t i = 0; i < numFlags; ++i) {
                 auto flag = VMType::from_instance(jvm_flag_type.get_type_name().c_str(), &flags_buf[i * jvm_flag_size]);
                 auto name_addr = flag->get_field<void *>("_name").value();
                 auto name = (char *)*name_addr;
                 LOG("FLAG: %s\n", name);
-
-                if (!name || strcmp(name, "AllowRedefinitionToAddDeleteMethods"))
+                if (!name)
                         continue;
 
-                auto addr = *flag->get_field<bool *>("_addr").value();
-                LOG("ADDR: %p\n", addr);
+                // Log flags containing "erif" or "Allow" to discover actual names
+                if (strstr(name, "erif") || strstr(name, "Allow") || strstr(name, "Bytecode"))
+                        LOGF("  flag[%zu]: %s", i, name);
 
-                auto value = reinterpret_cast<bool *>(addr);
-                LOG("VALUE: %d\n", (int)*value);
-
-                *value = true;
-                LOG("NEW VALUE: %d\n", (int)*value);
-
-                break;
+                // AllowRedefinitionToAddDeleteMethods: allow adding copy methods
+                if (strcmp(name, "AllowRedefinitionToAddDeleteMethods") == 0) {
+                        auto addr = *flag->get_field<bool *>("_addr").value();
+                        auto value = reinterpret_cast<bool *>(addr);
+                        LOGF("  PATCH %s: %d -> true", name, (int)*value);
+                        *value = true;
+                        patched++;
+                }
+                // BytecodeVerificationLocal/Remote: disable verification so
+                // RedefineClasses works on classes loaded with -noverify
+                else if (strcmp(name, "BytecodeVerificationLocal") == 0 ||
+                         strcmp(name, "BytecodeVerificationRemote") == 0) {
+                        auto addr = *flag->get_field<bool *>("_addr").value();
+                        auto value = reinterpret_cast<bool *>(addr);
+                        LOGF("  PATCH %s: %d -> false", name, (int)*value);
+                        *value = false;
+                        patched++;
+                }
         }
+        LOGF("Init: patched %d flags", patched);
 
         return JNIHOOK_OK;
 }
@@ -662,10 +769,15 @@ JNIHook_Attach(jmethodID method, void *native_hook_method, jmethodID *original_m
 {
         try {
                 return _JNIHook_Attach(method, native_hook_method, original_method);
-        } catch (jnif::Exception ex) {
+        } catch (jnif::Exception &ex) {
+                LOGF("Attach: JNIF exception: %s", ex.message.c_str());
                 LOG("ERR: JNIF exception thrown -> %s\n", ex.message.c_str());
                 return JNIHOOK_ERR_CLASS_FILE_FORMAT;
+        } catch (std::exception &ex) {
+                LOGF("Attach: std::exception: %s", ex.what());
+                LOG("ERR: Unhandled exception thrown\n");
         } catch (...) {
+                LOGF("Attach: unknown exception");
                 LOG("ERR: Unhandled exception thrown\n");
         }
         return JNIHOOK_ERR_UNKNOWN;
@@ -748,13 +860,12 @@ JNIHook_Shutdown()
         g_jnihook->jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL);
         g_jnihook->jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
 
-        jvmtiCapabilities caps{};
-		caps.can_redefine_classes = 1;
-		caps.can_redefine_any_class = 1;
-		caps.can_retransform_classes = 1;
-        caps.can_retransform_any_class = 1;
-		caps.can_suspend = 1;
-		jvmtiError err = g_jnihook->jvmti->RelinquishCapabilities(&caps);
+        // NOTE: Do NOT relinquish capabilities here.
+        // In HotSpot, can_retransform_classes is flagged at JVM startup and
+        // cannot be re-added once relinquished within the same JVM session.
+        // By keeping capabilities, any future jvmtiEnv can still obtain them,
+        // and the event+callbacks above are already cleared so no unmapped
+        // code will be called after library unload.
 
         g_jnihook = nullptr;
 

--- a/src/jnihook.cpp
+++ b/src/jnihook.cpp
@@ -28,7 +28,6 @@
 #include <unordered_map>
 #include <string>
 #include <vector>
-#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -40,20 +39,6 @@
 #else
         #define LOG(...)
 #endif
-
-// File-based debug logging (always active)
-static inline void jnihook_log(const char *fmt, ...) {
-        FILE *f = fopen("/tmp/inspection.log", "a");
-        if (!f) return;
-        va_list ap;
-        va_start(ap, fmt);
-        fprintf(f, "[jnihook] ");
-        vfprintf(f, fmt, ap);
-        fputc('\n', f);
-        va_end(ap);
-        fclose(f);
-}
-#define LOGF(...) jnihook_log(__VA_ARGS__)
 
 extern "C" JNIIMPORT VMStructEntry *gHotSpotVMStructs;
 extern "C" JNIIMPORT VMTypeEntry *gHotSpotVMTypes;
@@ -175,13 +160,10 @@ void JNICALL JNIHook_ClassFileLoadHook(jvmtiEnv *jvmti_env,
         // Calling get_class_name on NULL throws a JNI exception that poisons
         // the ongoing RetransformClasses call (JVMTI_ERROR_FAILS_VERIFICATION).
         if (!class_being_redefined) {
-                LOGF("ClassFileLoadHook: class_being_redefined=NULL, skipping (name=%s)", name ? name : "(null)");
                 return;
         }
 
         auto class_name = get_class_name(jni_env, class_being_redefined);
-        LOGF("ClassFileLoadHook: name='%s' force_cache=%d",
-             class_name.c_str(), (int)g_force_class_caching);
 
         // Don't do anything for unhooked classes
         // (unless g_force_class_caching is true)
@@ -228,9 +210,7 @@ ReapplyClass(jclass clazz, std::string clazz_name)
 {
         jvmtiClassDefinition class_definition;
         jvmtiError err;
-        LOGF("ReapplyClass: clazz_name='%s'", clazz_name.c_str());
         auto cf = g_class_file_cache[clazz_name]->clone();
-        LOGF("ReapplyClass: cloned, methods=%zu hooks=%zu", cf->methods.size(), g_hooks[clazz_name].size());
 
         // Patch class file
         // NOTE: The `methods` attribute only has the methods defined by the main class of this ClassFile
@@ -277,15 +257,12 @@ ReapplyClass(jclass clazz, std::string clazz_name)
         }
 
         // Redefine class with modified ClassFile
-        LOGF("ReapplyClass: calling toBytes()");
         auto cf_bytes = cf->toBytes();
-        LOGF("ReapplyClass: toBytes ok, size=%zu", cf_bytes.size());
 
         class_definition.klass = clazz;
         class_definition.class_byte_count = cf_bytes.size();
         class_definition.class_bytes = cf_bytes.data();
         err = g_jnihook->jvmti->RedefineClasses(1, &class_definition);
-        LOGF("ReapplyClass: RedefineClasses -> %d", (int)err);
         std::stringstream ss;
         LOG("===== CLASS REAPPLIED =====\n");
         ss << *cf;
@@ -305,11 +282,9 @@ jnihook_result_t
 CacheClass(JNIEnv *env, jclass clazz)
 {
         std::string clazz_name = get_class_name(env, clazz);
-        LOGF("CacheClass: clazz_name='%s'", clazz_name.c_str());
 
         if (g_class_file_cache.find(clazz_name) == g_class_file_cache.end()) {
                 auto enableRes = g_jnihook->jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL);
-                LOGF("CacheClass: EnableEvent -> %d", (int)enableRes);
                 if (enableRes != JVMTI_ERROR_NONE) {
                         LOG("ERR: Failed to enable class file load hook\n");
                         return JNIHOOK_ERR_SETUP_CLASS_FILE_LOAD_HOOK;
@@ -318,10 +293,8 @@ CacheClass(JNIEnv *env, jclass clazz)
                 g_force_class_caching = true;
                 auto result = g_jnihook->jvmti->RetransformClasses(1, &clazz);
                 g_force_class_caching = false;
-                LOGF("CacheClass: RetransformClasses -> %d", (int)result);
 
                 auto disableRes = g_jnihook->jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL);
-                LOGF("CacheClass: DisableEvent -> %d", (int)disableRes);
                 if (disableRes != JVMTI_ERROR_NONE) {
                         LOG("ERR: Failed to disable class file load hook\n");
                         return JNIHOOK_ERR_SETUP_CLASS_FILE_LOAD_HOOK;
@@ -331,12 +304,8 @@ CacheClass(JNIEnv *env, jclass clazz)
                 // failure), the ClassFileLoadHook may have already cached the
                 // class bytes, which is all we need for hooking.
                 if (g_class_file_cache.find(clazz_name) == g_class_file_cache.end()) {
-                        LOGF("CacheClass: FAIL class not cached, RetransformClasses error=%d", (int)result);
                         LOG("ERR: Failed to cache classfile\n");
                         return JNIHOOK_ERR_CLASS_FILE_CACHE;
-                }
-                if (result != JVMTI_ERROR_NONE) {
-                        LOGF("CacheClass: RetransformClasses error=%d but class is cached, proceeding", (int)result);
                 }
         }
 
@@ -524,21 +493,17 @@ JNIHook_Init(JavaVM *jvm)
         // to release its capabilities so a fresh env can acquire them.
         JNIEnv *jni = nullptr;
         jvm->GetEnv(reinterpret_cast<void **>(&jni), JNI_VERSION_1_8);
-        LOGF("Init: jni=%p", jni);
         if (jni) {
                 jvmtiEnv *old_jvmti = load_saved_jvmti(jni);
                 if (old_jvmti) {
-                        LOGF("Init: disposing old jvmti=%p", old_jvmti);
                         old_jvmti->DisposeEnvironment();
                 }
         }
 
         if (jvm->GetEnv(reinterpret_cast<void **>(&jvmti), JVMTI_VERSION_1_2) != JNI_OK) {
-                LOGF("Init: GetEnv JVMTI failed");
                 LOG("ERR: Failed to get JVMTI");
                 return JNIHOOK_ERR_GET_JVMTI;
         }
-        LOGF("Init: new jvmti=%p", jvmti);
 
         capabilities.can_redefine_classes = 1;
         capabilities.can_redefine_any_class = 1;
@@ -547,7 +512,6 @@ JNIHook_Init(JavaVM *jvm)
         capabilities.can_suspend = 1;
 
         auto capRes = jvmti->AddCapabilities(&capabilities);
-        LOGF("Init: AddCapabilities -> %d", (int)capRes);
         if (capRes != JVMTI_ERROR_NONE) {
                 LOG("ERR: Failed to add capabilities");
                 return JNIHOOK_ERR_ADD_JVMTI_CAPS;
@@ -592,7 +556,6 @@ JNIHook_Init(JavaVM *jvm)
 
         auto flags_buf = *(unsigned char **)flagsField; // flagTable
         auto numFlags = *numFlagsField;
-        LOGF("Init: scanning %zu JVM flags", (size_t)numFlags);
         int patched = 0;
         for (size_t i = 0; i < numFlags; ++i) {
                 auto flag = VMType::from_instance(jvm_flag_type.get_type_name().c_str(), &flags_buf[i * jvm_flag_size]);
@@ -602,15 +565,10 @@ JNIHook_Init(JavaVM *jvm)
                 if (!name)
                         continue;
 
-                // Log flags containing "erif" or "Allow" to discover actual names
-                if (strstr(name, "erif") || strstr(name, "Allow") || strstr(name, "Bytecode"))
-                        LOGF("  flag[%zu]: %s", i, name);
-
                 // AllowRedefinitionToAddDeleteMethods: allow adding copy methods
                 if (strcmp(name, "AllowRedefinitionToAddDeleteMethods") == 0) {
                         auto addr = *flag->get_field<bool *>("_addr").value();
                         auto value = reinterpret_cast<bool *>(addr);
-                        LOGF("  PATCH %s: %d -> true", name, (int)*value);
                         *value = true;
                         patched++;
                 }
@@ -620,12 +578,10 @@ JNIHook_Init(JavaVM *jvm)
                          strcmp(name, "BytecodeVerificationRemote") == 0) {
                         auto addr = *flag->get_field<bool *>("_addr").value();
                         auto value = reinterpret_cast<bool *>(addr);
-                        LOGF("  PATCH %s: %d -> false", name, (int)*value);
                         *value = false;
                         patched++;
                 }
         }
-        LOGF("Init: patched %d flags", patched);
 
         return JNIHOOK_OK;
 }
@@ -770,14 +726,11 @@ JNIHook_Attach(jmethodID method, void *native_hook_method, jmethodID *original_m
         try {
                 return _JNIHook_Attach(method, native_hook_method, original_method);
         } catch (jnif::Exception &ex) {
-                LOGF("Attach: JNIF exception: %s", ex.message.c_str());
                 LOG("ERR: JNIF exception thrown -> %s\n", ex.message.c_str());
                 return JNIHOOK_ERR_CLASS_FILE_FORMAT;
         } catch (std::exception &ex) {
-                LOGF("Attach: std::exception: %s", ex.what());
                 LOG("ERR: Unhandled exception thrown\n");
         } catch (...) {
-                LOGF("Attach: unknown exception");
                 LOG("ERR: Unhandled exception thrown\n");
         }
         return JNIHOOK_ERR_UNKNOWN;


### PR DESCRIPTION
* **Bug Fixes**
  * Improved NULL handling and defensive checks to avoid exceptions during class redefinition and loading.
  * Broadened exception handling for attachment paths and error cases.
  * Treated certain retransform errors as non‑fatal to proceed with caching when possible.

* **New Features**
  * Persisted runtime agent state to support reliable future injections.
  * Patch VM flags at startup to allow safer class redefinition and verification control.

* **Chores**
  * Expanded debug logging and diagnostics; retain capabilities across shutdowns for reload stability.
